### PR TITLE
Version 0.14.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,8 @@ requirements:
 outputs:
   - name: cachecontrol
     build:
-      skip: true  # [py<36]
-      script: {{ PYTHON }} -m pip install . -vv --no-deps
+      skip: true  # [py<37]
+      script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
       entry_points:
         - doesitcache = cachecontrol._cmd:main
     requirements:
@@ -59,7 +59,7 @@ outputs:
         - wheel
       run:
         - {{ pin_subpackage("cachecontrol", exact=True) }}
-        - python 
+        - python
         - redis-py >=2.10.5
     test: *test
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ outputs:
   - name: cachecontrol
     build:
       skip: true  # [py<37]
-      script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+      script: {{ PYTHON }} -m pip install . -vv --no-deps
       entry_points:
         - doesitcache = cachecontrol._cmd:main
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,15 +25,14 @@ outputs:
   - name: cachecontrol
     build:
       skip: true  # [py<37]
-      script: {{ PYTHON }} -m pip install . -vv --no-deps
+      script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
       entry_points:
         - doesitcache = cachecontrol._cmd:main
     requirements:
       host:
         - python
         - pip
-        - setuptools
-        - wheel
+        - flit-core
       run:
         - python
         - requests >=2.16.0
@@ -54,8 +53,7 @@ outputs:
       host:
         - python
         - pip
-        - setuptools
-        - wheel
+        - flit-core
       run:
         - {{ pin_subpackage("cachecontrol", exact=True) }}
         - python
@@ -69,8 +67,7 @@ outputs:
       host:
         - python
         - pip
-        - setuptools
-        - wheel
+        - flit-core
       run:
         - {{ pin_subpackage("cachecontrol", exact=True) }}
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   skip: true  # [py<36]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,8 +37,8 @@ outputs:
         - wheel
       run:
         - python
-        - requests
-        - msgpack-python >=0.5.2
+        - requests >=2.16.0
+        - msgpack-python >=0.5.2, <2.0.0
     test: &test
       requires:
         - pip
@@ -75,7 +75,7 @@ outputs:
       run:
         - {{ pin_subpackage("cachecontrol", exact=True) }}
         - python
-        - lockfile >=0.9
+        - filelock >=3.8.0
     test: *test
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<36]
+  skip: true  # [py<37]
 
 requirements:
   host:
@@ -48,7 +48,7 @@ outputs:
 
   - name: cachecontrol-with-redis
     build:
-      skip: true  # [py<36]
+      skip: true  # [py<37]
     requirements:
       host:
         - python
@@ -62,7 +62,7 @@ outputs:
 
   - name: cachecontrol-with-filecache
     build:
-      skip: true  # [py<36]
+      skip: true  # [py<37]
     requirements:
       host:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,12 @@
-{% set version = "0.12.11" %}
-{% set sha256 = "a5b9fcc986b184db101aa280b42ecdcdfc524892596f606858e0b7a8b4d9e144" %}
+{% set version = "0.14.0" %}
+{% set sha256 = "7db1195b41c81f8274a7bbd97c956f44e8348265a1bc7641c37dfebc39f0c938" %}
 
 package:
   name: cachecontrol-split
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/C/CacheControl/CacheControl-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/C/CacheControl/cachecontrol-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,7 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
-    - wheel
+    - flit-core >=3.2,<4
   run:
     - python
 


### PR DESCRIPTION
cachecontrol 0.14.0

**Destination channel:** defaults

### Links

- [PKG-4349](https://anaconda.atlassian.net/browse/PKG-4349)
- [Upstream repository](https://github.com/psf/cachecontrol/tree/v0.14.0)
- [Upstream changelog/diff](https://github.com/psf/cachecontrol/releases)

### Explanation of changes:

- Update version
- Update dependencies
- Linter fixes


[PKG-4349]: https://anaconda.atlassian.net/browse/PKG-4349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ