### PR TITLE
cachecontrol 0.14.3 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,22 +1,22 @@
-{% set version = "0.14.0" %}
-{% set sha256 = "7db1195b41c81f8274a7bbd97c956f44e8348265a1bc7641c37dfebc39f0c938" %}
+{% set name = "CacheControl" %}
+{% set version = "0.14.3" %}
 
 package:
-  name: cachecontrol-split
+  name: {{ name|lower }}-split
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/C/CacheControl/cachecontrol-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|lower }}-{{ version }}.tar.gz
+  sha256: 73e7efec4b06b20d9267b441c1f733664f989fb8688391b670ca812d70795d11
 
 build:
-  number: 1
+  number: 0
   skip: true  # [py<37]
 
 requirements:
   host:
-    - python
     - pip
+    - python
     - flit-core >=3.2,<4
   run:
     - python
@@ -30,8 +30,8 @@ outputs:
         - doesitcache = cachecontrol._cmd:main
     requirements:
       host:
-        - python
         - pip
+        - python
         - flit-core
       run:
         - python
@@ -51,8 +51,8 @@ outputs:
       skip: true  # [py<37]
     requirements:
       host:
-        - python
         - pip
+        - python
         - flit-core
       run:
         - {{ pin_subpackage("cachecontrol", exact=True) }}


### PR DESCRIPTION
cachecontrol 0.14.3 

**Destination channel:** Defaults

### Links

- [PKG-10305]
- dev_url:        https://github.com/ionrock/cachecontrol/tree/v0.14.3
- conda_forge:    https://github.com/conda-forge/cachecontrol-feedstock
- pypi:           https://pypi.org/project/cachecontrol/0.14.3
- pypi inspector: https://inspector.pypi.io/project/cachecontrol/0.14.3

### Explanation of changes:

- new version number


[PKG-10305]: https://anaconda.atlassian.net/browse/PKG-10305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ